### PR TITLE
Following the update to Pillow

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -213,7 +213,7 @@ psycopg2 = 2.6.1
 publicsuffix = 1.1.0
 # python-cjson is used by zif.jsonserver
 python-cjson = 1.1.0
-Pillow = 3.1.1
+Pillow = 3.3.0
 requests = 2.9.1
 # "reportlab" is deprecated: it is only used by "trml2pdf"
 reportlab = 3.3.0


### PR DESCRIPTION
Plone went with Pillow 3.2.0, but I think we can get away with 3.3.0 
https://plone.org/news/2016/minor-plone-security-fixes