### PR TITLE
Maybe we don't need egenix-mx-base?

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -178,7 +178,6 @@ zope-eggs =
 # Products that lack ZCML files.
 eggs = ${buildout:custom-eggs}
        ${buildout:zope-eggs}
-       egenix-mx-base
        funcsigs
        five.formlib
        FeedParser

--- a/dependencies.cfg
+++ b/dependencies.cfg
@@ -14,12 +14,6 @@ unzip = true
 recipe = zc.recipe.egg
 eggs = i18ndude == 4.0.1
 
-[egenix-mx-base]
-# Used mostly by the database code
-recipe = vortex.recipe.setup_install
-url = http://eggs.iopen.net/groupserver/cache/egenix-mx-base-3.2.9.zip
-package = mx
-
 [wsgi]
 recipe = collective.recipe.modwsgi
 eggs = ${buildout:eggs}


### PR DESCRIPTION
Dropping egenix-mx-base because http://egenix.com/ has gone, and it looks like GroupServer works without it!