### PR TITLE
Clarify some points in docs

### DIFF
--- a/docs/groupserver-install.rst
+++ b/docs/groupserver-install.rst
@@ -97,6 +97,8 @@ system, and finally `start Zope`_.
 .. index::
    pair: Configuration; Host name
 
+.. _Pick Hostname:
+
 Pick a host name
 ----------------
 

--- a/docs/postfix-configure.rst
+++ b/docs/postfix-configure.rst
@@ -146,6 +146,14 @@ Ubuntu.
 
          smtpd_authorized_verp_clients = 127.0.0.1,localhost
 
+#.  Forward your mailing list domains to GroupServer by adding
+    them to the end of the
+    :file:`/etc/postfix/groupserver.virtual` file, like so
+
+      .. code-block:: cfg
+
+        @groups.example.com groupserver-automagic@localhost
+
 #.  Generate the Postfix hashes by running :command:`postmap` and
     :command:`postalias`:
 


### PR DESCRIPTION
Hi,

Thanks for GroupServer! I ran into some issues during install and modified the docs accordingly.

1. It was unclear how Postfix forwards mail to GroupServer's automagic handler. I added a bit to the Postfix conf docs to clarify that you need to add your domains for it to work, eg `@groups.example.com groupserver-automagic@localhost`

2. Nginx server configuration must contain `listen [::]:80;` in addition to `listen 80;` to support IPv6. Without this, the server blocks will be ignored and nginx will select the first server block it finds. This confused me for about an hour because nginx was selecting a different site other than GroupServer until I added this.

3. I made the nginx upstream block consistent with the section about selecting a custom hostname, using `gstest:8080` instead of `localhost:8080` and reminding users they should change it to whatever they set earlier.

4. I simplified the nginx ZMI configuration by putting it into a location block rather than a sever block. I'm not sure if the docs are outdated here, but a subdomain isn't needed; ZMI lives at `/manage`. This also confused me quite a bit and resulted in [this strange error](http://groupserver.org/groups/development/messages/topic/roBMKRWjFfO6XnYt2UKMg/).

5. I expanded on the DNS configuration section, rewording it to be easier to understand and providing examples.

I tested this on nginx on my own install and it is working great. I did not update the Apache section with these changes because I don't have an Apache install to test with. The updated nginx instructions shouldn't conflict with the Apache section, although I am concerned the Apache configuration will have the same issues I ran into with the nginx one and may need to be updated accordingly.

Let me know if you disagree or if I need to change anything. This is my first experience setting up a mailing list server and configuring Postfix manually. I hope my changes here will help others.

Thanks!